### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/conda-and-cmake.yml
+++ b/.github/workflows/conda-and-cmake.yml
@@ -44,3 +44,46 @@ jobs:
       - name: Build
         working-directory: ${{ github.workspace }}/build
         run: cmake --build . --config ${{ matrix.build-type }}
+
+  build-windows:
+    runs-on: windows-latest
+
+    env:
+      build-type: Release
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.8
+          channels: conda-forge
+          channel-priority: true
+
+      - name: Show conda installation info
+        run: conda info
+
+      - name: Install build tools and dependencies into env
+        run: |
+          conda install --file=requirements.txt
+          conda list
+
+      - name: Make cmake build directory
+        run: cmake -E make_directory build
+
+      - name: Configure, build, and test
+        shell: cmd /C CALL {0}
+        working-directory: ${{ github.workspace }}\build
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.16 10.0.19041.0
+
+          :: Configure
+          cmake ^
+            -LAH -G "NMake Makefiles" ^
+            -DPKG_CONFIG_EXECUTABLE:FILEPATH=C:/Miniconda/envs/test/Library/bin/pkg-config.exe ^
+            -DCMAKE_BUILD_TYPE=${{ env.build-type }} ^
+            ${{ github.workspace }}\src
+
+          :: Build and install
+          cmake --build . --target install --config ${{ env.build-type }}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0)
+include(CheckIncludeFile)
 
-project (cdm CXX)
+# project (cdm CXX)
+project (cdm)
 
 set (CDM_VERSION 3.0)
 
@@ -8,6 +10,19 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(FFTW3 REQUIRED IMPORTED_TARGET fftw3)
 include_directories(${FFTW3_INCLUDE_DIRS})
 link_directories(${FFTW3_LIBRARY_DIRS})
+
+check_include_file(unistd.h WITH_UNISTD)
+check_include_file(sys/utsname.h WITH_UTSNAME)
+find_library(LIB_M m)
+
+if (WITH_UNISTD)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_UNISTD")
+endif (WITH_UNISTD)
+if (WITH_UTSNAME)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_UTSNAME")
+endif (WITH_UTSNAME)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_USE_MATH_DEFINES")
 
 set(
   CDM_SRCS
@@ -38,9 +53,14 @@ set(
 )
 
 add_executable(coastal-dune-model main.cc ${CDM_SRCS})
-target_link_libraries(coastal-dune-model fftw3)
+if (LIB_M)
+  target_link_libraries(coastal-dune-model fftw3 m)
+elseif (NOT LIB_M)
+  target_link_libraries(coastal-dune-model fftw3)
+endif (LIB_M)
 
 install(
   TARGETS coastal-dune-model
   RUNTIME DESTINATION bin
 )
+

--- a/src/PTG_Func2dScalar.cc
+++ b/src/PTG_Func2dScalar.cc
@@ -3,6 +3,7 @@
  ******************************************************************************/
 
 #include <iostream>
+
 #include <math.h>
 #include "globals.h"
 #include "PTG_Func2dScalar.h"
@@ -147,13 +148,13 @@ double PTG_Func2dScalar::CenterOfMassX() const
     for (int x=0; x < SizeX(); x++) {
         double linesum= 0.0;
         for (int y=0; y < SizeY(); y++)
-            if( finite((*this)(x, y)) )
+            if( isfinite((*this)(x, y)) )
                 linesum += (*this)(x,y);
         xsum += linesum * x;
         sum += linesum;
     }
     centerx= Delta()*xsum/sum;
-    if( finite(centerx) )
+    if( isfinite(centerx) )
         return centerx;
     else
         return Delta()*SizeX()/2.0;

--- a/src/globals.cc
+++ b/src/globals.cc
@@ -5,7 +5,9 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+#ifdef WITH_UNISTD
+  #include <unistd.h>
+#endif
 #include <errno.h>
 #include <math.h>
 
@@ -463,11 +465,13 @@ duneglobals::duneglobals( const dunepar& parameters )
         "'.  Data directory doesn't exist or permission denied.  Aborting.\n";
         exit(1);
     }
+#ifdef WITH_UNISTD
     if( !S_ISDIR(savedirstat.st_mode) ) {
         cerr << "duneglobals constructor:  Data directory `" << m_datadir <<
         "' is not a directory.  Aborting.\n";
         exit(1);
     }
+#endif
 }
 
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,9 +3,11 @@
 ******************************************************************************/
 
 #include <time.h>
-#include <sys/utsname.h>
+#ifdef WITH_UTSNAME
+  #include <sys/utsname.h>
+#endif
 #include <sys/types.h>
-#include <unistd.h>
+// #include <unistd.h>
 
 #include "globals.h"
 #include "dune_evolution.h"
@@ -39,12 +41,16 @@ parameter file version, a CPde object (for backward compatibility; version <
 CApp::CApp(int argc, char **argv) : m_evol(0)
 
 {
+#ifdef UTSNAME
   struct utsname u;
+#endif
   time_t t= time(NULL);
   
+#ifdef UTSNAME
   if( !uname(&u) )
     cout << "Running on " << u.nodename << ", machine type " << u.machine << ", with process id " << getpid() << "\n";
   cout << ctime( &t ) << "\n";
+#endif
 
   // find name for parameter file
   // Format for command line arguments: <token>=<value>, for instance 

--- a/src/shear_hlr.cc
+++ b/src/shear_hlr.cc
@@ -178,7 +178,7 @@ double shearHLR::CalcPertTau(TFktScal& h, TFktVec& tau)
             ky2= ky*ky;
             ka= sqrt(kx2+ky2);
             
-        	if( (!finite(fft_h.freqre(x, y)) || !finite(fft_h.freqim(x, y))) && !naninfwarned ) {
+        	if( (!isfinite(fft_h.freqre(x, y)) || !isfinite(fft_h.freqim(x, y))) && !naninfwarned ) {
           		fprintf(stderr, "CShearHLR::CalcPertTau:  NAN or INF in fft_h after FT.\n");
           		naninfwarned= true;
         	}
@@ -226,7 +226,7 @@ double shearHLR::CalcPertTau(TFktScal& h, TFktVec& tau)
     }
     L = Int/(Int_x*m_dkx);
     
-    if( !finite(L) )	L= iNx;
+    if( !isfinite(L) )	L= iNx;
     
     return L;
 }

--- a/src/wind.cc
+++ b/src/wind.cc
@@ -2,6 +2,7 @@
  $Id: wind.cc,v 1.5 2004/12/22 10:21:57 schatz Exp $
  ******************************************************************************/
 
+#include <random>
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>
@@ -118,7 +119,8 @@ wind_flatrand::wind_flatrand(const dunepar& par)
     m_dir0= par.getdefault( "flatwind.avgdir", 0.0 ) / 360.0;
     m_ddir= par.getrequired<double>( "flatwind.ddir" ) / 360.0;
     
-    initstate( time(NULL), m_statearray, 256 );
+    // initstate( time(NULL), m_statearray, 256 );
+    srand(1973);
 }
 
 
@@ -130,17 +132,19 @@ void wind_flatrand::advance( double )
 {
     char *prevrngstate;
     
-    prevrngstate= setstate(m_statearray);
+    // prevrngstate = setstate(m_statearray);
+    srand(1973);
     if( m_ddir==0.0 )
         m_dir= m_dir0;
     else
-        m_dir= m_dir0 + m_ddir * 2.0 * ((double)random()/(double)RAND_MAX - 0.5);
+        m_dir= m_dir0 + m_ddir * 2.0 * ((double)rand()/(double)RAND_MAX - 0.5);
     if( m_dustar==0.0 )
         m_ustar= m_ustar0;
     else
         m_ustar= m_ustar0 +
-	    m_dustar * 2.0 * ((double)random()/(double)RAND_MAX - 0.5);
-    setstate(prevrngstate);
+	    m_dustar * 2.0 * ((double)rand()/(double)RAND_MAX - 0.5);
+    // setstate(prevrngstate);
+    srand(1973);
 }
 
 


### PR DESCRIPTION
This pull request tries to fix CDM to build on Windows (see csdms/help-desk#96).

* `unistd.h` and `utsname.h` are not available on Windows. *cmake* now checks to see if these header files are available and, if not, excludes code that uses them.
* `random`, `setstate`, and `initstate` are not available on Windows. I've changed *wind.cc* to use the more standard `rand` and `srand`.
* `finite` is not available. As a fix, I've changed `finite` to `isfinite`.

This still needs to be tested and the Linux and Mac builds checked to make sure the above changes didn't break them.